### PR TITLE
bugfix in hantek 6022BL voltage range selection

### DIFF
--- a/hw/hantek-6022bl/fw.c
+++ b/hw/hantek-6022bl/fw.c
@@ -100,7 +100,7 @@ static BOOL set_voltage(BYTE channel, BYTE val)
 		return FALSE;
 	}
 
-	bits = bits << (channel ? 1 : 4);
+	bits = bits << (channel ? 4 : 1);
 	mask = (channel) ? 0x70 : 0x0e;
 	IOA = (IOA & ~mask) | (bits & mask);
 


### PR DESCRIPTION
I always had trouble to select the correct voltage range for the analog channels. I also checked hat the scope works properly under windows. After taking a close look at the firmwares "set_voltage" function it became clear, that the shift and the mask do not match. The shift was wrong. If channel 0 is used, bits 1,2, and 3 of Port A must be changed and not 4,5, and 6. The mask also shows that.